### PR TITLE
Also filter {revision} if it appears in dependencyManagement

### DIFF
--- a/src/it/replace-revision-in-pom/pom.xml
+++ b/src/it/replace-revision-in-pom/pom.xml
@@ -16,4 +16,14 @@
     ${revision} should be replaced by 1.0-SNAPSHOT
   </description>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>fr.jcgay.maven.extension.urmf</groupId>
+        <artifactId>replace-revision-in-pom-commons</artifactId>
+        <version>${revision}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/src/it/replace-revision-in-pom/verify.groovy
+++ b/src/it/replace-revision-in-pom/verify.groovy
@@ -9,5 +9,6 @@ assert projectInTarget.version == '1.0-SNAPSHOT'
 File pom = new File("$localRepositoryPath/fr/jcgay/maven/extension/urmf/replace-revision-in-pom/1.0-SNAPSHOT/replace-revision-in-pom-1.0-SNAPSHOT.pom")
 def project = new XmlSlurper().parse(pom)
 assert project.version == '1.0-SNAPSHOT'
+assert project.dependencyManagement.dependencies[0].dependency.version == '1.0-SNAPSHOT'
 
 return true

--- a/src/test/groovy/fr/jcgay/maven/extension/revision/UniqueRevisionFilteringTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/extension/revision/UniqueRevisionFilteringTest.groovy
@@ -156,4 +156,37 @@ class UniqueRevisionFilteringTest extends Specification {
         project.parent.version == 'dumb'
         project.version == 'dumb'
     }
+
+    def 'updates versions in dependencyManagement that are set to ${revision}'() {
+        given:
+        pom << """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.jcgay.example.version</groupId>
+    <artifactId>dep-mgmt-test</artifactId>
+    <version>\${revision}</version>
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.jcgay.example.version</groupId>
+                <artifactId>dep-mgmt-test-commons</artifactId>
+                <version>\${revision}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+        """
+        def artifact = new SubArtifact(new DefaultArtifact('fr.jcgay.test', 'jar-id', 'jar', '1.0-SNAPSHOT'), null, 'pom', pom)
+
+        when:
+        def result = uniqueRevision.transformArtifact(artifact)
+
+        then:
+        def project = new XmlSlurper().parse(result.file)
+        project.version == '1.0-SNAPSHOT'
+        project.dependencyManagement.dependencies[0].dependency.version == '1.0-SNAPSHOT'
+    }
 }


### PR DESCRIPTION
Closes #13.

Note that I've added some logging (both info and debug) to the output of the extension's operation.  I'm happy to discuss or reduce this if you would prefer.

Looking forward to your thoughts!