### PR TITLE
Added rewriting the ${revision} for dependencies and removing the par…

### DIFF
--- a/src/main/java/fr/jcgay/maven/extension/revision/UniqueRevisionFiltering.java
+++ b/src/main/java/fr/jcgay/maven/extension/revision/UniqueRevisionFiltering.java
@@ -57,6 +57,17 @@ class UniqueRevisionFiltering implements MetadataGenerator {
             logger.debug("Filtering ${revision} in <parent><version> field");
             hasRevisionNumber = true;
             parent.setVersion(artifact.getBaseVersion());
+            parent.setRelativePath("");
+        }
+
+        if(pom.getDependencies() != null){
+            for (Dependency dependency : pom.getDependencies()) {
+                if (isRevision(dependency.getVersion())) {
+                    logger.debug("Filtering ${revision} in dependency of " + dependency.getGroupId() + ":" + dependency.getArtifactId());
+                    dependency.setVersion(artifact.getBaseVersion());
+                    hasRevisionNumber = true;
+                }
+            }
         }
 
         if (pom.getDependencyManagement() != null && pom.getDependencyManagement().getDependencies() != null) {

--- a/src/test/groovy/fr/jcgay/maven/extension/revision/UniqueRevisionFilteringTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/extension/revision/UniqueRevisionFilteringTest.groovy
@@ -167,7 +167,7 @@ class UniqueRevisionFilteringTest extends Specification {
     <groupId>com.github.jcgay.example.version</groupId>
     <artifactId>dep-mgmt-test</artifactId>
     <version>\${revision}</version>
-    
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -188,5 +188,63 @@ class UniqueRevisionFilteringTest extends Specification {
         def project = new XmlSlurper().parse(result.file)
         project.version == '1.0-SNAPSHOT'
         project.dependencyManagement.dependencies[0].dependency.version == '1.0-SNAPSHOT'
+    }
+
+    def 'updates versions in dependencies that are set to ${revision}'() {
+        given:
+        pom << """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.jcgay.example.version</groupId>
+    <artifactId>dep-mgmt-test</artifactId>
+    <version>\${revision}</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.jcgay.example.version</groupId>
+            <artifactId>dep-mgmt-test-commons</artifactId>
+            <version>\${revision}</version>
+        </dependency>
+    </dependencies>
+</project>
+        """
+        def artifact = new SubArtifact(new DefaultArtifact('fr.jcgay.test', 'jar-id', 'jar', '1.0-SNAPSHOT'), null, 'pom', pom)
+
+        when:
+        def result = uniqueRevision.transformArtifact(artifact)
+
+        then:
+        def project = new XmlSlurper().parse(result.file)
+        project.version == '1.0-SNAPSHOT'
+        project.dependencies[0].dependency.version == '1.0-SNAPSHOT'
+    }
+
+    def 'replace the parent path with a default path'() {
+        given:
+        pom << """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.jcgay.example.version</groupId>
+        <artifactId>parent-pom</artifactId>
+        <version>\${revision}</version>
+        <relativePath>../blabla</relativePath>
+    </parent>
+
+    <artifactId>submodule-1</artifactId>
+    <version>\${revision}</version>
+</project>
+        """
+        def artifact = new SubArtifact(new DefaultArtifact('fr.jcgay.test', 'jar-id', 'jar', '1.0-SNAPSHOT'), null, 'pom', pom)
+
+        when:
+        def result = uniqueRevision.transformArtifact(artifact)
+
+        then:
+        def project = new XmlSlurper().parse(result.file)
+        project.parent.relativePath == ''
     }
 }


### PR DESCRIPTION
Hi Jean-Christophe,

I have found your library and used it to push a multi module project into my repository but it I missed two functions.
- Removing the relative part of the parent pom
- Rewriting the dependency $revision to the actual version.
Which I both needed to use the pom for another project as a parent pom

Not sure if this is wanted but I needed itanyway and it seems to work, so I thought maybe it is a good addition.

Tijs